### PR TITLE
feat: support full game sequences without beliefs

### DIFF
--- a/src/misc/ps_data_generator_sequence.py
+++ b/src/misc/ps_data_generator_sequence.py
@@ -179,21 +179,6 @@ def append_to_data_file(data, file_path):
         with open(file_path, 'wb') as f:
             pickle.dump(data, f)
 
-def create_belief_vector(opponent_types, current_opponents):
-    """
-    Create a simplified belief vector representing opponent types.
-    
-    Args:
-        opponent_types: List of opponent type names
-        current_opponents: Dictionary of current opponent information
-    
-    Returns:
-        np.ndarray: Simple belief vector (one-hot encoding of known opponents)
-    """
-    # For simplicity in this implementation, we'll just pass the opponent types as a list
-    # In a real implementation, you would encode this as a proper belief vector
-    return [opp_info["name"] for agent, opp_info in current_opponents.items()]
-
 def generate_data(
     num_episodes=1000,
     output_dir="./ps_data",
@@ -206,8 +191,9 @@ def generate_data(
     max_rounds_per_episode=50
 ):
     """
-    Generate training data using Perfect Search, organized by game (with rounds in sequence)
-    and tagging each step by agent_id (0=training, 1=opponent1, 2=opponent2).
+    Generate training data using Perfect Search, producing a single full-game
+    sequence for each episode and tagging each step by agent_id
+    (0=training, 1=opponent1, 2=opponent2).
     """
     import random
     import time
@@ -296,8 +282,6 @@ def generate_data(
             models[name] = instance
         return opponents, models
 
-    def create_belief_vector(opponent_types, opponents):
-        return [info["name"] for _, info in opponents.items()]
 
     logger = setup_logging(os.path.join(output_dir, 'generation.log'), logging.INFO if verbose else logging.WARNING)
     random.seed(start_seed)
@@ -312,7 +296,6 @@ def generate_data(
 
     stats = {
         "episodes": 0,
-        "rounds": 0,
         "steps": 0,
         "wins": 0,
         "losses": 0,
@@ -340,34 +323,18 @@ def generate_data(
         obs, infos = env.reset(seed=episode_seed)
         ps = PerfectSearch(env=env, training_agent=training_agent, opponent_models=opponent_models)
 
-        game_data = {"game_id": episode, "rounds": []}
-        current_round = env.round
+        game_data = {"game_id": episode, "sequence": [],
+                      "game_outcome": {"winner": None, "penalties": {}, "result": 0.0}}
         episode_step = 0
-        round_step = 0
 
-        current_round_sequence = {"round_id": f"{episode}_{current_round}", "episode_id": episode, "table_card": env.table_card, "sequence": [], "round_outcome": {"winner": None, "penalties": {}, "result": 0.0}}
-
-        while not all(env.terminations.values()) and episode_step < 1000 and len(game_data["rounds"]) < max_rounds_per_episode:
+        while not all(env.terminations.values()) and episode_step < 1000:
             episode_step += 1
-            round_step += 1
             current_agent = env.agent_selection
-
-            if env.round > current_round or current_agent is None:
-                if len(current_round_sequence["sequence"]) >= 2:
-                    current_round_sequence["round_outcome"].update({"winner": env.winner, "penalties": {a: env.penalties.get(a, 0) for a in env.possible_agents}, "result": 100.0 if env.winner == training_agent else -100.0 if env.winner else 0.0})
-                    game_data["rounds"].append(current_round_sequence)
-                    stats["rounds"] += 1
-                    stats["avg_sequence_length"] = ((stats["avg_sequence_length"] * (stats["rounds"] - 1)) + len(current_round_sequence["sequence"])) / stats["rounds"]
-                if current_agent is None:
-                    break
-                current_round = env.round
-                round_step = 0
-                current_round_sequence = {"round_id": f"{episode}_{current_round}", "episode_id": episode, "table_card": env.table_card, "sequence": [], "round_outcome": {"winner": None, "penalties": {}, "result": 0.0}}
 
             if current_agent is None:
                 break
 
-            step_data = {"agent_id": AGENT_ID_MAP[current_agent], "step_in_round": round_step}
+            step_data = {"agent_id": AGENT_ID_MAP[current_agent], "step": episode_step}
 
             if current_agent == training_agent:
                 obs_curr = env.observe(current_agent, newer=True)[current_agent]
@@ -397,7 +364,6 @@ def generate_data(
                         step_data["action_source"] = "Error Fallback"
                 step_data["action"] = best_action
                 step_data["action_probs"] = action_probs.tolist()
-                step_data["belief"] = create_belief_vector(selected_opponents, current_opponents)
                 action_type, _, count = decode_action(best_action)
                 stats["action_distribution"][f"{action_type}_{count}"] += 1
                 if action_type == "Play" and count is not None:
@@ -416,41 +382,38 @@ def generate_data(
                     best_action = opp_model.play_turn(obs_opp, mask, table_card=env.table_card) if hasattr(opp_model, 'play_turn') else mask.index(1)
                     step_data["action_source"] = f"Opponent Model ({current_opponents[current_agent]['name']})"
                 step_data["action"] = best_action
-                step_data["belief"] = create_belief_vector(selected_opponents, current_opponents)
                 action_type, _, count = decode_action(best_action)
                 if action_type == "Play" and count is not None:
                     step_data["card_count"] = count
                     if np.random.random() < opponent_action_dropout_rate:
                         step_data["transformed_action"] = CARD_COUNT_MAPPING.get(count, count + 6)
                 env.step(best_action)
-            current_round_sequence["sequence"].append(step_data)
+            game_data["sequence"].append(step_data)
             stats["steps"] += 1
+        game_data["game_outcome"].update({
+            "winner": env.winner,
+            "penalties": {a: env.penalties.get(a, 0) for a in env.possible_agents},
+            "result": 100.0 if env.winner == training_agent else -100.0 if env.winner else 0.0
+        })
 
         if env.winner == training_agent:
             stats["wins"] += 1
         elif env.winner is not None:
             stats["losses"] += 1
         stats["episodes"] += 1
-        stats["win_rate"] = stats["wins"] / stats["episodes"]
-        if len(current_round_sequence["sequence"]) >= 2:
-            current_round_sequence["round_outcome"].update({"winner": env.winner, "penalties": {a: env.penalties.get(a, 0) for a in env.possible_agents}, "result": 100.0 if env.winner == training_agent else -100.0 if env.winner else 0.0})
-            game_data["rounds"].append(current_round_sequence)
-            stats["rounds"] += 1
-            stats["avg_sequence_length"] = ((stats["avg_sequence_length"] * (stats["rounds"] - 1)) + len(current_round_sequence["sequence"])) / stats["rounds"]
+        stats["win_rate"] = stats["wins"] / stats["episodes"] if stats["episodes"] else 0.0
+
+        seq_len = len(game_data["sequence"])
+        stats["avg_sequence_length"] = ((stats["avg_sequence_length"] * (stats["episodes"] - 1)) + seq_len) / stats["episodes"]
         current_batch_games.append(game_data)
         if (episode + 1) % save_frequency == 0:
             append_to_data_file(current_batch_games, main_data_file)
-            stats["total_saved_sequences"] += sum(len(g["rounds"]) for g in current_batch_games)
+            stats["total_saved_sequences"] += len(current_batch_games)
             current_batch_games = []
 
     if current_batch_games:
         append_to_data_file(current_batch_games, main_data_file)
-        stats["total_saved_sequences"] += sum(len(g["rounds"]) for g in current_batch_games)
-
-    # Final save if there's remaining data not yet saved
-    if len(current_batch_games) > 0:
-        append_to_data_file(current_batch_games, main_data_file)
-        stats["total_saved_sequences"] += sum(len(g["rounds"]) for g in current_batch_games)
+        stats["total_saved_sequences"] += len(current_batch_games)
 
     # Save stats to file
     stats_file = os.path.join(output_dir, "stats_final.json")
@@ -461,7 +424,7 @@ def generate_data(
     # Calculate final statistics
     total_time = time.time() - stats["start_time"]
     stats["total_time"] = total_time
-    total_sequences = stats["rounds"]
+    total_sequences = stats["total_saved_sequences"]
     stats["sequences_per_episode"] = total_sequences / max(1, stats["episodes"])
     stats["steps_per_sequence"] = stats["steps"] / max(1, total_sequences)
     stats["episodes_per_second"] = stats["episodes"] / max(1, total_time)

--- a/src/model/autoregressive_model.py
+++ b/src/model/autoregressive_model.py
@@ -17,11 +17,11 @@ class AutoregressiveGameModel(nn.Module):
     - Action prediction with proper masking of invalid actions
     - Support for both explicit actions (0-6)
     """
-    def __init__(self, 
-                 obs_dim, 
+    def __init__(self,
+                 obs_dim,
                  action_dim=7,
-                 belief_dim=20,
-                 hidden_dim=256, 
+                 belief_dim=None,
+                 hidden_dim=256,
                  num_heads=4,
                  num_layers=2,
                  dropout_rate=0.1,
@@ -32,7 +32,11 @@ class AutoregressiveGameModel(nn.Module):
         Args:
             obs_dim: Dimension of observation vectors
             action_dim: Number of possible actions (typically 7 for Liar's Deck)
-            belief_dim: Dimension of belief vectors (if None, belief encoder is not used)
+            belief_dim: Dimension of belief vectors. If ``None`` the model will not
+                use external belief inputs. This allows training on full game
+                sequences without a separate belief model while remaining
+                backwards compatible with older checkpoints that expect a belief
+                vector.
             hidden_dim: Hidden dimension for transformer and other layers
             num_heads: Number of attention heads in transformer
             num_layers: Number of transformer layers
@@ -109,18 +113,19 @@ class AutoregressiveGameModel(nn.Module):
         # Learnable null token for padding (initialized as zeros)
         self.null_token = nn.Parameter(torch.zeros(hidden_dim))
     
-    def _encode_inputs(self, obs_sequence, belief_sequence, action_sequence, 
-                      agent_types, positions, action_masks=None):
+    def _encode_inputs(self, obs_sequence, belief_sequence=None, action_sequence=None,
+                      agent_types=None, positions=None, action_masks=None):
         """
         Encode all inputs into a unified sequence representation.
         
         Args:
-            obs_sequence: Tensor of shape [batch_size, seq_len, obs_dim] or None for steps
-            belief_sequence: Tensor of shape [batch_size, seq_len, belief_dim] or None
-            action_sequence: Tensor of shape [batch_size, seq_len] - previous actions
-            agent_types: Tensor of shape [batch_size, seq_len] - 0=training agent, 1=opponent
-            positions: Tensor of shape [batch_size, seq_len] - positions in sequence
-            action_masks: Tensor of shape [batch_size, seq_len, action_dim] or None
+            obs_sequence: Tensor of shape ``[batch_size, seq_len, obs_dim]`` or ``None``
+            belief_sequence: Optional tensor of shape ``[batch_size, seq_len, belief_dim]``
+            action_sequence: Tensor of shape ``[batch_size, seq_len]`` with previous actions
+            agent_types: Tensor of shape ``[batch_size, seq_len]`` where 0 denotes the
+                training agent and 1 an opponent
+            positions: Tensor of shape ``[batch_size, seq_len]`` indicating positions
+            action_masks: Optional tensor of shape ``[batch_size, seq_len, action_dim]``
         
         Returns:
             Tensor of shape [batch_size, seq_len, hidden_dim]
@@ -194,24 +199,22 @@ class AutoregressiveGameModel(nn.Module):
         mask = torch.arange(seq_len, device=device).expand(batch_size, seq_len) >= valid_lens.unsqueeze(1)
         return mask
     
-    def forward(self, obs_sequence=None, belief_sequence=None, action_sequence=None, 
+    def forward(self, obs_sequence=None, belief_sequence=None, action_sequence=None,
                 agent_types=None, positions=None, action_masks=None, valid_lengths=None):
-        """
-        Forward pass through the model.
-        
+        """Forward pass through the model.
+
         Args:
-            obs_sequence: Tensor of observations [batch_size, seq_len, obs_dim] or None
-            belief_sequence: Tensor of beliefs [batch_size, seq_len, belief_dim] or None
-            action_sequence: Tensor of previous actions [batch_size, seq_len]
-            agent_types: Tensor indicating agent type [batch_size, seq_len] (0=ours, 1=opponent)
-            positions: Tensor of positions in sequence [batch_size, seq_len]
-            action_masks: Tensor of action masks [batch_size, seq_len, action_dim] or None
-            valid_lengths: Tensor of valid sequence lengths [batch_size] or None
-        
+            obs_sequence: Tensor of observations ``[batch, seq, obs_dim]`` or ``None``.
+            belief_sequence: Optional tensor of beliefs ``[batch, seq, belief_dim]``.
+            action_sequence: Tensor of previous actions ``[batch, seq]``.
+            agent_types: Tensor indicating agent type ``[batch, seq]`` (0=ours, 1=opponent).
+            positions: Tensor of positions in sequence ``[batch, seq]``.
+            action_masks: Optional tensor of action masks ``[batch, seq, action_dim]``.
+            valid_lengths: Optional tensor of valid sequence lengths ``[batch]``.
+
         Returns:
-            tuple: (action_logits, extended_action_logits, state_values)
-                action_logits: Tensor of shape [batch_size, seq_len, action_dim]
-                state_values: Tensor of shape [batch_size, seq_len, 1]
+            Tuple ``(action_logits, opp_logits, state_values)`` where each tensor has
+            shape ``[batch, seq, ...]``.
         """
         batch_size, seq_len = action_sequence.shape
         device = action_sequence.device

--- a/src/training/train_autoregressive_model.py
+++ b/src/training/train_autoregressive_model.py
@@ -199,7 +199,7 @@ class AutoregressiveGameDataset(Dataset):
             raw_actions = []
             raw_target_actions = []
             for step in sequence:
-                is_train = step.get("is_training_agent", False)
+                is_train = step.get("is_training_agent", step.get("agent_id", 0) == 0)
                 if "action" in step:
                     a = step["action"]
                     b = step["action"]
@@ -210,13 +210,13 @@ class AutoregressiveGameDataset(Dataset):
                     a = step["transformed_action"]
                 raw_target_actions.append(b)
                 raw_actions.append(a)
-            
+
             raw_actions = [6 if a == 10 else a for a in raw_actions]
             raw_target_actions = [6 if a == 10 else a for a in raw_target_actions]
             # 2) Build shifted inputs and aligned targets
             PAD = 0
-            input_actions  = [PAD] + raw_actions[:-1]  # length == seq_len
-            target_actions = raw_target_actions.copy() # length == seq_len
+            input_actions  = [PAD] + raw_actions[:-1]
+            target_actions = raw_target_actions.copy()
 
             # 3) Build the rest of the features in one pass
             obs_list = []
@@ -224,6 +224,7 @@ class AutoregressiveGameDataset(Dataset):
             agent_type_list = []
             position_list = []
             belief_list = []
+            has_belief = False
 
             latest_belief_vector = None
             LABELS = {
@@ -238,29 +239,25 @@ class AutoregressiveGameDataset(Dataset):
             }
 
             for i, step in enumerate(sequence):
-                # agent type & position
-                is_train = step.get("is_training_agent", False)
+                is_train = step.get("is_training_agent", step.get("agent_id", 0) == 0)
                 agent_type_list.append(0 if is_train else 1)
                 position_list.append(i)
 
-                # observation (only for training agent)
                 if is_train:
                     obs = np.array(step["observation"], dtype=np.float32)
                     obs_list.append(obs)
                 else:
                     obs_list.append(np.zeros(7, dtype=np.float32))
 
-                # action mask
                 if is_train and "action_mask" in step:
                     action_mask_list.append(step["action_mask"])
                 else:
                     action_mask_list.append([0] * 7)
 
-                # belief (external list of opponent names)
                 if "belief" in step:
+                    has_belief = True
                     names = step["belief"]
                     full_belief = []
-                    # two opponents assumed
                     for opp_idx in range(2):
                         vec = np.zeros(len(LABELS), dtype=np.float32)
                         if opp_idx < len(names):
@@ -275,44 +272,40 @@ class AutoregressiveGameDataset(Dataset):
                         full_belief.extend(vec)
                     latest_belief_vector = np.array(full_belief, dtype=np.float32)
                     belief_list.append(latest_belief_vector)
-                else:
-                    # fallback to last belief or uniform
-                    if latest_belief_vector is not None:
-                        belief_list.append(latest_belief_vector)
-                    else:
-                        uniform = np.ones(len(LABELS), dtype=np.float32) / len(LABELS)
-                        fb = np.concatenate([uniform, uniform])
-                        latest_belief_vector = fb
-                        belief_list.append(fb)
+                elif has_belief and latest_belief_vector is not None:
+                    belief_list.append(latest_belief_vector)
 
             # 4) Convert lists into tensors
             obs_tensor        = torch.tensor(np.stack(obs_list),       dtype=torch.float32, device=device)
             action_tensor     = torch.tensor(input_actions,            dtype=torch.long,    device=device)
             target_tensor     = torch.tensor(target_actions,           dtype=torch.long,    device=device)
             mask_tensor       = torch.tensor(np.array(action_mask_list), dtype=torch.bool,  device=device)
-            belief_tensor     = torch.tensor(np.stack(belief_list),    dtype=torch.float32, device=device)
             agent_type_tensor = torch.tensor(agent_type_list,          dtype=torch.long,    device=device)
             position_tensor   = torch.tensor(position_list,            dtype=torch.long,    device=device)
+            belief_tensor = None
+            if has_belief:
+                belief_tensor = torch.tensor(np.stack(belief_list),    dtype=torch.float32, device=device)
 
-            # causal attention mask (optional—model can recompute internally)
             attention_mask = torch.triu(
                 torch.ones(seq_len, seq_len, device=device, dtype=torch.bool),
                 diagonal=1
             )
 
-            # 5) Store the processed sequence
-            self.sequences.append({
+            seq_dict = {
                 "obs":            obs_tensor,
                 "action":         action_tensor,
                 "target_action":  target_tensor,
                 "action_mask":    mask_tensor,
-                "belief":         belief_tensor,
                 "agent_type":     agent_type_tensor,
                 "position":       position_tensor,
                 "attention_mask": attention_mask,
                 "length":         seq_len,
-                "round_id":       round_data["round_id"]
-            })
+                "round_id":       round_data.get("round_id", round_data.get("game_id", None))
+            }
+            if belief_tensor is not None:
+                seq_dict["belief"] = belief_tensor
+
+            self.sequences.append(seq_dict)
 
         # summary
         print(f"Processed {len(self.sequences)} sequences (from {self.total_sequences} total)")
@@ -350,14 +343,16 @@ def collate_variable_length_sequences(batch):
     first_seq = batch[0]
     device = first_seq['obs'].device
     obs_dim = first_seq['obs'].shape[1]
-    belief_dim = first_seq['belief'].shape[1]
-    
+    has_belief = 'belief' in first_seq and first_seq['belief'] is not None
+    belief_dim = first_seq['belief'].shape[1] if has_belief else 0
+
     # Initialize tensors for the batch
     batched_obs = torch.zeros(batch_size, max_seq_len, obs_dim, device=device)
     batched_action = torch.zeros(batch_size, max_seq_len, dtype=torch.long, device=device)
     batched_target_action = torch.zeros(batch_size, max_seq_len, dtype=torch.long, device=device)
     batched_action_mask = torch.zeros(batch_size, max_seq_len, 7, dtype=torch.bool, device=device)
-    batched_belief = torch.zeros(batch_size, max_seq_len, belief_dim, device=device)
+    if has_belief:
+        batched_belief = torch.zeros(batch_size, max_seq_len, belief_dim, device=device)
     batched_agent_type = torch.zeros(batch_size, max_seq_len, dtype=torch.long, device=device)
     batched_position = torch.zeros(batch_size, max_seq_len, dtype=torch.long, device=device)
     
@@ -380,7 +375,8 @@ def collate_variable_length_sequences(batch):
         batched_action[i, :seq_len] = seq['action']
         batched_target_action[i, :seq_len] = seq['target_action']
         batched_action_mask[i, :seq_len] = seq['action_mask']
-        batched_belief[i, :seq_len] = seq['belief']
+        if has_belief:
+            batched_belief[i, :seq_len] = seq['belief']
         batched_agent_type[i, :seq_len] = seq['agent_type']
         batched_position[i, :seq_len] = seq['position']
         
@@ -391,18 +387,20 @@ def collate_variable_length_sequences(batch):
         round_ids.append(seq['round_id'])
     
     # Return as a dictionary
-    return {
+    batch_dict = {
         'obs': batched_obs,
         'action': batched_action,
         'target_action': batched_target_action,
         'action_mask': batched_action_mask,
-        'belief': batched_belief,
         'agent_type': batched_agent_type,
         'position': batched_position,
         'padding_mask': padding_mask,
         'lengths': lengths,
         'round_ids': round_ids
     }
+    if has_belief:
+        batch_dict['belief'] = batched_belief
+    return batch_dict
 
 def load_autoreg_data(data_dir, max_files=None, max_samples=None):
     """Load data from PS autoregressive data pickle files.
@@ -464,13 +462,22 @@ def load_autoreg_data(data_dir, max_files=None, max_samples=None):
 
                 if len(data) > remaining:
                     sampled_data = random.sample(data, remaining)
-                    all_data.extend(sampled_data)
-                    total_loaded += len(sampled_data)
+                else:
+                    sampled_data = data
+
+                # Flatten legacy game->round structure if needed
+                for item in sampled_data:
+                    if isinstance(item, dict) and 'rounds' in item:
+                        all_data.extend(item['rounds'])
+                        total_loaded += len(item['rounds'])
+                    else:
+                        all_data.append(item)
+                        total_loaded += 1
+
+                if len(data) > remaining:
                     print(f"Sampled {len(sampled_data)} from {os.path.basename(data_file)} ({len(data)} total)")
                 else:
-                    all_data.extend(data)
-                    total_loaded += len(data)
-                    print(f"Loaded all {len(data)} sequences from {os.path.basename(data_file)}")
+                    print(f"Loaded all {len(sampled_data)} sequences from {os.path.basename(data_file)}")
         except Exception as e:
             print(f"Error loading {os.path.basename(data_file)}: {e}")
             continue
@@ -612,7 +619,7 @@ def train_autoregressive_model(
 
     sample = next(iter(train_loader))
     obs_dim = sample['obs'].shape[2]
-    belief_dim = sample['belief'].shape[2]
+    belief_dim = sample['belief'].shape[2] if 'belief' in sample else None
     action_dim = 7
     logger.info(f"Model dimensions: obs_dim={obs_dim}, belief_dim={belief_dim}, action_dim={action_dim}")
 
@@ -660,7 +667,7 @@ def train_autoregressive_model(
         for batch in train_progress:
             self_logits, opp_logits, value_pred = model(
                 obs_sequence=batch['obs'],
-                belief_sequence=batch['belief'],
+                belief_sequence=batch.get('belief'),
                 action_sequence=batch['action'],
                 agent_types=batch['agent_type'],
                 positions=batch['position']
@@ -725,7 +732,7 @@ def train_autoregressive_model(
             for batch in val_progress:
                 self_logits, opp_logits, value_pred = model(
                     obs_sequence=batch['obs'],
-                    belief_sequence=batch['belief'],
+                    belief_sequence=batch.get('belief'),
                     action_sequence=batch['action'],
                     agent_types=batch['agent_type'],
                     positions=batch['position']


### PR DESCRIPTION
## Summary
- allow autoregressive model to omit belief inputs and handle full length games
- generate full game sequences without beliefs
- train pipeline loads new format and handles optional beliefs

## Testing
- `pytest` *(fails: ModuleNotFoundError/SystemExit)*


------
https://chatgpt.com/codex/tasks/task_e_688e7290d650832381a38f35eb846641